### PR TITLE
docs: streamline informative headings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
-# CHANGELOG (Informative)
+# CHANGELOG
 
-This page mirrors the repository root `CHANGELOG.md`. Refer to that file for authoritative release notes.
+_Informative._ This page mirrors the repository root `CHANGELOG.md`. Refer to that file for authoritative release notes.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ Use this index to navigate ADF v0.5.0 artifacts.
 - [Glossary](glossary.md)
 - [Governance](governance.md)
 - [Contributing](contributing.md)
-- [Preview Build Workflow (Informative)](guide/website-preview.md)
+- [Preview Build Workflow](guide/website-preview.md) _(informative guide)_
 
 For historical documents, explore the `docs/specs/archive/` directory and legacy guides under `docs/method/` and `docs/guide/`.
 

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -1,9 +1,11 @@
 ---
-title: ADF Audits (Informative)
+title: ADF Audits
 slug: /audits
 ---
 
 # ADF Audits
+
+_Informative._ Audit reports provide optional references; the normative method remains in `docs/specs`.
 
 - This folder contains **dated, immutable** audit documents of the ADF repo.
 - Naming: `YYYY-MM-DD-adf-audit.md`

--- a/docs/examples/github/labels.md
+++ b/docs/examples/github/labels.md
@@ -1,5 +1,5 @@
 ---
-title: GitHub Labels (Informative)
+title: GitHub Labels
 sidebar_label: Labels CSV
 ---
 

--- a/docs/examples/github/required-checks.md
+++ b/docs/examples/github/required-checks.md
@@ -1,5 +1,5 @@
 ---
-title: Required Checks (Informative)
+title: Required Checks
 sidebar_label: Required Checks
 slug: /examples/github/required-checks
 ---

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,8 @@
-# Frequently Asked Questions (Informative)
+# Frequently Asked Questions
 
-**Is ADF more complex than Scrum?**  
+_Informative._ Use this FAQ to clarify common adoption and operations questions.
+
+**Is ADF more complex than Scrum?**
 No. Scrum roles, events, and artifacts remain intact. ADF adds guardrails (CR-First, SSP, Delivery Pulse) without new ceremonies. See the [Agile/Scrum map](overview/agile-scrum-map.md).
 
 **Do we need extra meetings?**  

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,4 +1,6 @@
-# ADF Glossary (Informative)
+# ADF Glossary
+
+_Informative._ Use this glossary to align on shared terminology when applying the ADF specification.
 
 | Term | Definition |
 | --- | --- |

--- a/docs/guide/website-preview.md
+++ b/docs/guide/website-preview.md
@@ -1,5 +1,5 @@
 ---
-title: Preview Build Workflow (Informative)
+title: Preview Build Workflow
 description: Steps for running the informative Docusaurus site locally and verifying the GitHub Pages deployment.
 ---
 

--- a/docs/handbook/metrics.md
+++ b/docs/handbook/metrics.md
@@ -26,9 +26,9 @@ This guide explains how to compute and report the metrics defined in [Section 8 
 | Change Failure Rate (CFR) | Percentage of CRs requiring hotfix or rollback within defined window. | Weekly review. |
 | Mean Time to Restore (MTTR) | Average time to restore service after incident triggered by a change. | Incident retrospectives. |
 
-### Optional Metrics (Informative)
+### Optional Metrics
 
-Optional metrics **MUST NOT** block merges unless organizational policy explicitly elevates them to mandatory status.
+_Informative._ Optional metrics **MUST NOT** block merges unless organizational policy explicitly elevates them to mandatory status.
 
 | Metric | Definition | Target Cadence |
 | --- | --- | --- |

--- a/docs/overview/adoption-guide.md
+++ b/docs/overview/adoption-guide.md
@@ -1,6 +1,6 @@
-# Adoption Guide (Informative)
+# Adoption Guide
 
-ADF adoption follows a three-level ladder. Each level builds on Scrum without adding ceremonies. Use the checklists to stage your rollout.
+_Informative._ ADF adoption follows a three-level ladder. Each level builds on Scrum without adding ceremonies. Use the checklists to stage your rollout.
 
 ## Level 1 — Foundations
 - Enable the [PR template](../templates/pr-template.md) and Story Preview checklist.

--- a/docs/overview/agile-scrum-map.md
+++ b/docs/overview/agile-scrum-map.md
@@ -1,6 +1,6 @@
-# Agile/Scrum Map (Informative)
+# Agile/Scrum Map
 
-ADF preserves the Scrum skeleton. Use this alignment to explain the overlay quickly.
+_Informative._ ADF preserves the Scrum skeleton. Use this alignment to explain the overlay quickly.
 
 | Scrum Element | ADF Alignment | Notes |
 | --- | --- | --- |

--- a/docs/overview/quickstart-l1.md
+++ b/docs/overview/quickstart-l1.md
@@ -1,6 +1,6 @@
-# L1 Quickstart (Informative)
+# L1 Quickstart
 
-Adopt ADF foundations in a single day. Pair this playbook with the [Adoption Guide](adoption-guide.md) and formal rules in the [Specification](../specs/adf-spec-v0.5.0.md).
+_Informative._ Adopt ADF foundations in a single day. Pair this playbook with the [Adoption Guide](adoption-guide.md) and formal rules in the [Specification](../specs/adf-spec-v0.5.0.md).
 
 ## Morning — Prepare the Workspace
 - Add the [PR template](../templates/pr-template.md) and Story Preview checklist to your repository.

--- a/docs/overview/start-here.md
+++ b/docs/overview/start-here.md
@@ -1,6 +1,6 @@
-# Start Here (Informative)
+# Start Here
 
-The Agentic Delivery Framework (ADF) keeps **Scrum as the baseline** while adding agent-aware safety rails. It combines:
+_Informative._ The Agentic Delivery Framework (ADF) keeps **Scrum as the baseline** while adding agent-aware safety rails. It combines:
 
 - **Change Request (CR)-First flow** so every Increment is governed by a single merge request.
 - **Sequential Subtask Pipeline (SSP)** to serialize human/agent contributions on one Story branch.

--- a/docs/profiles/github.md
+++ b/docs/profiles/github.md
@@ -3,9 +3,9 @@ title: "GitHub Profile — ADF v0.5.0"
 summary: "Mapping ADF v0.5.0 controls to GitHub features, with references to examples and templates."
 ---
 
-# GitHub Platform Profile (Informative)
+# GitHub Platform Profile
 
-This profile explains how to implement the [ADF v0.5.0 specification](../specs/adf-spec-v0.5.0.md) using GitHub features. It is informative and **MUST NOT** be interpreted as normative configuration. Use it as a guide when tailoring repository settings.
+_Informative._ This profile explains how to implement the [ADF v0.5.0 specification](../specs/adf-spec-v0.5.0.md) using GitHub features. It is informative and **MUST NOT** be interpreted as normative configuration. Use it as a guide when tailoring repository settings.
 
 > **Informative guidance:** All mappings below illustrate one way to fulfill the specification on GitHub. Teams MAY implement equivalent controls on any platform.
 

--- a/docs/templates/codeowners.example.md
+++ b/docs/templates/codeowners.example.md
@@ -1,8 +1,10 @@
 ---
-title: CODEOWNERS Example (Informative)
+title: CODEOWNERS Example
 ---
 
-This page mirrors the [`CODEOWNERS` example](codeowners.example) for quick reference. Copy the raw file when applying to your repository.
+_Informative._ This reference mirrors the [`CODEOWNERS` example](codeowners.example) for quick application.
+
+Copy the raw file when applying to your repository.
 
 ```text
 # Example CODEOWNERS for ADF v0.5.0 (documentation only; do not copy verbatim)

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -67,7 +67,7 @@ const sidebars: SidebarsConfig = {
   profiles: [
     {
       type: 'category',
-      label: 'Profiles (Informative)',
+      label: 'Profiles',
       collapsed: false,
       items: [
         'profiles/overview',
@@ -83,7 +83,7 @@ const sidebars: SidebarsConfig = {
   examples: [
     {
       type: 'category',
-      label: 'Examples (Informative)',
+      label: 'Examples',
       collapsed: true,
       items: [
         'examples/github/labels',
@@ -97,7 +97,7 @@ const sidebars: SidebarsConfig = {
   audits: [
     {
       type: 'category',
-      label: 'Audits (Informative)',
+      label: 'Audits',
       collapsed: true,
       items: [
         'audits/README',


### PR DESCRIPTION
## Summary
- remove the “(Informative)” suffix from overview entry points (Start Here, Adoption Guide, Agile/Scrum Map, Quickstart) and replace it with inline informative callouts to improve readability while keeping labels explicit
- normalize informative callouts across supporting references (Changelog, Glossary, FAQ, CODEOWNERS example, GitHub profile, audits, GitHub examples) and update the docs index link text
- tidy the Docusaurus sidebar category labels so navigation no longer shows “(Informative)” while the pages remain tool-agnostic guidance for any platform

These updates keep the documentation platform-neutral and continue to distinguish informative material from the normative specification.

## Testing
- npm ci --prefix website
- CI=1 npm run build --prefix website

## Checklist
- [x] Links checked via Docusaurus build
- [x] Terminology stays aligned with the canonical glossary
- [x] Neutrality review confirms there are no vendor-locked instructions

------
https://chatgpt.com/codex/tasks/task_e_68e27e95df4483249e5f2cedb9f1ddd6