### PR TITLE
chore: remove license notice from github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,5 +27,3 @@ Describe the problem and where it appears (file, section, link).
 Relevant links, screenshots, or reference implementation notes.
 
 ---
-
-This methodology/spec is licensed under CC BY-SA 4.0.

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -28,5 +28,3 @@ As a ___, I want ___ so that ___.
 Additional context, diagrams, or supporting links.
 
 ---
-
-This methodology/spec is licensed under CC BY-SA 4.0.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -22,5 +22,3 @@ Related stories, RFCs, changelog entries, or external implementation issues.
 - [ ] Follow-up actions captured in roadmap or reference repos
 
 ---
-
-This methodology/spec is licensed under CC BY-SA 4.0.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,5 +13,3 @@
 - [ ] Documentation updated across affected files (including license notice)
 
 ---
-
-This methodology/spec is licensed under CC BY-SA 4.0.

--- a/.github/workflows/license-notice-check.yml
+++ b/.github/workflows/license-notice-check.yml
@@ -23,6 +23,11 @@ jobs:
             if [ -z "$file" ]; then
               continue
             fi
+            case "$file" in
+              .github/ISSUE_TEMPLATE/*|.github/PULL_REQUEST_TEMPLATE.md)
+                continue
+                ;;
+            esac
             if ! grep -Fq "$license_line" "$file"; then
               missing_files+="$file\n"
             fi


### PR DESCRIPTION
## Summary
- remove the CC BY-SA license footer from the GitHub issue and PR templates
- update the license notice workflow to skip GitHub templates when scanning for the footer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e282955dc08324ad68d051ccf6a8bf