### PR TITLE
Add CC BY-SA notices to publishing automation assets

### DIFF
--- a/.github/workflows/backflow-public.yml
+++ b/.github/workflows/backflow-public.yml
@@ -1,4 +1,3 @@
-# This work is licensed under CC BY-SA 4.0.
 name: Backflow ← Public (allowlist NO-CODE)
 
 on:
@@ -41,3 +40,5 @@ jobs:
           title: "Backflow: sync changes from public"
           body: "This PR syncs NO-CODE allowlisted files from the public repo back into internal."
           labels: "backflow"
+
+# This work is licensed under CC BY-SA 4.0.

--- a/.github/workflows/backflow-public.yml
+++ b/.github/workflows/backflow-public.yml
@@ -1,3 +1,4 @@
+# This work is licensed under CC BY-SA 4.0.
 name: Backflow ← Public (allowlist NO-CODE)
 
 on:

--- a/.github/workflows/publish-public.yml
+++ b/.github/workflows/publish-public.yml
@@ -1,4 +1,3 @@
-# This work is licensed under CC BY-SA 4.0.
 name: Publish → Public (NO-CODE export)
 
 on:
@@ -67,3 +66,5 @@ jobs:
           git remote add public https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/airnub/agentic-delivery-framework.git
           git branch -M main
           git push public main:main --follow-tags
+
+# This work is licensed under CC BY-SA 4.0.

--- a/.github/workflows/publish-public.yml
+++ b/.github/workflows/publish-public.yml
@@ -1,3 +1,4 @@
+# This work is licensed under CC BY-SA 4.0.
 name: Publish → Public (NO-CODE export)
 
 on:

--- a/.oss.publish.yml
+++ b/.oss.publish.yml
@@ -1,3 +1,4 @@
+# This work is licensed under CC BY-SA 4.0.
 version: 1
 public_repo: airnub/agentic-delivery-framework
 default_branch: main

--- a/.oss.publish.yml
+++ b/.oss.publish.yml
@@ -1,4 +1,3 @@
-# This work is licensed under CC BY-SA 4.0.
 version: 1
 public_repo: airnub/agentic-delivery-framework
 default_branch: main
@@ -66,3 +65,5 @@ deny:
   - Makefile*
   - **/.env*
   - **/.git*
+
+# This work is licensed under CC BY-SA 4.0.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -21,3 +21,5 @@
 
 ## Secrets (Informative)
 - `PUBLISH_APP_ID` and `PUBLISH_APP_PRIVATE_KEY` store GitHub App credentials for the publish workflow.
+
+This work is licensed under CC BY-SA 4.0.


### PR DESCRIPTION
## Summary
- add the CC BY-SA 4.0 license comment to the backflow and publish workflows
- annotate the OSS publish manifest with the CC BY-SA 4.0 notice
- append the standard CC BY-SA footer to `docs/publishing.md` to keep the methodology guidance consistent and tool-agnostic

## Testing
- not run (docs and config only)

## Checklist
- [x] Links: Not applicable (no links added or modified)
- [x] Terminology: Verified required gate names and terms remain consistent
- [x] Neutrality: Confirmed content stays tool-agnostic


------
https://chatgpt.com/codex/tasks/task_e_68e28d80bb288324afedac638c8715c4