### PR TITLE
docs: document autonomy-with-accountability principle

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The Agentic Delivery Framework (ADF) is a vendor-neutral methodology for human +
 
 ## Specification & guidance
 - **Specifications:** [ADF v0.5.0 (latest)](docs/specs/adf-spec-v0.5.0.md), [ADF v0.4.0](docs/specs/spec.v0.4.0.md), [Specification changelog](docs/specs/changelog.md).
+- **Guiding principle:** Autonomy-with-Accountability → [docs/vision/autonomy-principle.md](docs/vision/autonomy-principle.md).
 - **Handbook:** [ADF v0.5.0 Handbook index](docs/handbook/README.md) with focused guides for [SSP](docs/handbook/ssp.md), [CR gates](docs/handbook/cr-gates.md), [Story Preview](docs/handbook/story-preview.md), [Pulse Increment](docs/handbook/pulse-increment.md), [Conformance](docs/handbook/conformance.md), [Evidence Bundle](docs/handbook/evidence-bundle.md), [Metrics](docs/handbook/metrics.md), and [Agent safety rails](docs/handbook/safety-rails.md).
 - **Templates:** [PR template](docs/templates/pr-template.md), [Story Preview template](docs/templates/story-preview.md), [Labels](docs/templates/labels.md), [CODEOWNERS example](docs/templates/codeowners.example), [Conformance checklist](docs/templates/conformance-checklist.md), legacy [CR checklist](docs/templates/cr-checklist.md).
 - **Profiles & examples:** [Profiles overview](docs/profiles/overview.md), [GitHub profile](docs/profiles/github.md), [GitHub examples](docs/examples/github/).

--- a/docs/specs/adf-spec-v0.5.0.md
+++ b/docs/specs/adf-spec-v0.5.0.md
@@ -5,6 +5,8 @@ summary: "Normative specification for ADF v0.5.0 including CR-first invariant, S
 
 # Agentic Delivery Framework (ADF) v0.5.0 Specification
 
+> _Informative note:_ See [ADF Guiding Principle: Autonomy-with-Accountability](../vision/autonomy-principle.md) for the overarching autonomy vision.
+
 > **Status:** Latest (v0.5.0). v0.4.0 remains normative for teams pinned to the previous minor version.
 
 ## Table of Contents

--- a/docs/vision/autonomy-principle.md
+++ b/docs/vision/autonomy-principle.md
@@ -1,0 +1,13 @@
+# ADF Guiding Principle: Autonomy-with-Accountability
+
+**North Star.** ADF aims for 24×7 autonomous delivery where agents can plan, build, test, and re-plan the Product Backlog continuously—with humans shifting from “doers” to **governors** of goals, policy, and exceptions.
+
+**How we get there.**
+- **Policy-as-Code Gates:** Every agent action is funneled through CRs and measurable gates (spec, tests, security, supply chain, performance, framework/mode policy, preview, approvals).
+- **Progressive Trust:** Teams opt into **Autonomy Levels (A0–A4)** that expand agent permissions only when evidence shows safety.
+- **Inspectability:** Story Previews, Evidence Bundles, telemetry, and Pulse reports make work legible to humans and machines.
+- **Reversibility:** Changes are small, reviewable, and can be rolled back; feature flags and migration plans are mandatory for risky updates.
+- **Budgets:** Cost and risk budgets bound autonomy economically and operationally.
+- **Human Governance:** Delivery Pulse and Retros keep humans in the loop for priorities, exceptions, and policy evolution.
+
+This principle is non-normative; see the ADF specification for requirements.


### PR DESCRIPTION
## Summary
- add an autonomy-with-accountability guiding principle page under docs/vision
- link the new principle from the repository README and the v0.5.0 specification introduction
- cross-reference keeps the methodology documentation vendor-neutral and tool-agnostic

## Testing
- n/a

## Checklist
- [x] Links validated
- [x] Terminology and gate names follow canonical usage
- [x] Confirmed content remains vendor-neutral and tool-agnostic

------
https://chatgpt.com/codex/tasks/task_e_68e2d80073e083249c2be0bcffc32603