### PR TITLE
docs: wire roadmap/principle + autonomy stubs (A3/A4, budgets, ledger)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The Agentic Delivery Framework (ADF) is a vendor-neutral methodology for human +
 - **Profiles & examples:** [Profiles overview](docs/profiles/overview.md), [GitHub profile](docs/profiles/github.md), [GitHub examples](docs/examples/github/).
 - **Diagrams:** [ADF method overview](docs/diagrams/adf-method-overview.mmd), [SSP flow](docs/diagrams/ssp-flow.mmd), [Pulse increment](docs/diagrams/pulse-increment.mmd), plus neutral diagrams in `docs/diagrams/`.
 - **Legacy references:** [Conformance levels (pre-v0.5)](docs/conformance.md), [Method SSP design](docs/method/ssp-sequential-subtask-pipeline.v0.1.0.md), [Guide handbook](docs/guide/handbook.md).
+- **Appendices:**
+  - [Enterprise mapping: Evidence ↔ SOC2/ISO, metrics ↔ DORA, CAB-lite policy](docs/specs/appendix-enterprise-mapping.md).
 
 ## Method diagram
 

--- a/docs/handbook/cr-gates.md
+++ b/docs/handbook/cr-gates.md
@@ -31,6 +31,27 @@ All gates run on every CR unless explicitly bypassed via `break-glass`. Required
 | `preview-build` | Story Preview assets successfully generated and attached. | Artifact link, screenshot thumbnail, build log. |
 | `human-approval` | Required reviewers approved. | Reviewer list, approval timestamps, CODEOWNERS match. |
 
+### `cost-budget`
+
+- **Purpose:** Constrain spend for each CR by defining token or USD ceilings per Story and cumulative caps per repository or organization.
+- **Operation:** Delivery Leads declare the budget in the Story Preview. Pipelines enforce ceilings and fail when forecasts exceed limits.
+- **Evidence:** Record the declared ceiling, actual consumption, and variance within the Evidence Bundle (`gates/cost-budget.json` or equivalent neutral format).
+- **Policy:** OPTIONAL for autonomy levels A0–A2; **REQUIRED** for components operating at Autonomy Levels A3–A4.
+
+### `risk-budget`
+
+- **Purpose:** Guard blast radius by assigning risk tiers to paths and features.
+- **Operation:** Map repository paths to low, medium, or high tiers. Medium and high tiers **MUST** ship behind feature flags or equivalent toggles.
+- **Evidence:** Include the evaluated tier, gating decision, and mitigating flag reference in the Evidence Bundle. Update the risk register when thresholds change.
+- **Policy:** OPTIONAL for autonomy levels A0–A2; **REQUIRED** for components operating at Autonomy Levels A3–A4.
+
+### `lease-broker`
+
+- **Purpose:** Enforce single-writer semantics for each Story by verifying that only the active lease holder commits changes.
+- **Operation:** Automations apply labels `lease:active` and `lease:released` as the Story Lease transitions. The CI check `adf/lease-broker` **MUST** fail when multiple writers or expired leases attempt to push.
+- **Evidence:** Capture lease events and check outputs in the Evidence Bundle. Reference the Agent Run Ledger when agents execute under the lease.
+- **Policy:** OPTIONAL for autonomy levels A0–A2; **REQUIRED** for components operating at Autonomy Levels A3–A4.
+
 ## Gate Procedures
 
 1. **Pre-flight:** Ensure the Story Preview declares scope, risks, and dependencies. This prevents avoidable gate failures.

--- a/docs/handbook/evidence-bundle.md
+++ b/docs/handbook/evidence-bundle.md
@@ -62,6 +62,27 @@ other legacy filenames as migration artifacts and update them to this canonical 
 - Index bundles by CR ID, Story ID, and Sprint for easy retrieval.
 - Mirror metadata in the risk register or compliance tracker.
 
+## Agent Run Ledger
+
+The Agent Run Ledger captures deterministic provenance for automated execution. It is **REQUIRED** for autonomy levels A2 and above and **SHALL** be hash-linked (previous hash to current hash) for A3–A4 Story components.
+
+Store the ledger entry inside the Evidence Bundle (for example `provenance/agent-run-ledger.json`) using a schema similar to the example below:
+
+```json
+{
+  "model": {"name": "gpt-5-codex", "version": "2024-05-15", "hash": "sha256-abc123"},
+  "prompts": {"system_sha": "sha256-sys000", "user_sha": "sha256-user999"},
+  "tools": {"edit": "v1.2.3", "tests": "v0.9.5"},
+  "datasets": {"fixtures": "sha256-fixture555"},
+  "cost": {"tokens": 45872, "usd": 12.44},
+  "risk": {"tier": "medium", "flag": "feature-flag/payment-toggle"},
+  "prev_hash": "sha256-ledger-prev", 
+  "hash": "sha256-ledger-current"
+}
+```
+
+> **Note:** Include additional neutral keys (such as environment version or story lease ID) when necessary, but retain the core provenance fields above for audit parity.
+
 ## Audit Checklist
 
 Auditors **SHOULD** verify:

--- a/docs/profiles/azure-devops/README.md
+++ b/docs/profiles/azure-devops/README.md
@@ -1,0 +1,3 @@
+# Azure DevOps Profile (Placeholder)
+
+Placeholder profile. The methodology is vendor-neutral; this stub documents how to wire gates/labels/settings on this platform.

--- a/docs/profiles/gitlab/README.md
+++ b/docs/profiles/gitlab/README.md
@@ -1,0 +1,3 @@
+# GitLab Profile (Placeholder)
+
+Placeholder profile. The methodology is vendor-neutral; this stub documents how to wire gates/labels/settings on this platform.

--- a/docs/specs/adf-spec-v0.5.0.md
+++ b/docs/specs/adf-spec-v0.5.0.md
@@ -5,8 +5,7 @@ summary: "Normative specification for ADF v0.5.0 including CR-first invariant, S
 
 # Agentic Delivery Framework (ADF) v0.5.0 Specification
 
-_Related: See the non-normative [ADF Roadmap to 24×7 Autonomous Delivery](../roadmaps/adf-roadmap-autonomous-delivery.md) for an adoption path and design intent._
-> _Informative note:_ See [ADF Guiding Principle: Autonomy-with-Accountability](../vision/autonomy-principle.md) for the overarching autonomy vision.
+_Related:_ See **[ADF Roadmap to 24×7 Autonomous Delivery](../roadmaps/adf-roadmap-autonomous-delivery.md)** for adoption steps, and the **[Autonomy-with-Accountability](../vision/autonomy-principle.md)** principle for the north star.
 
 > **Status:** Latest (v0.5.0). v0.4.0 remains normative for teams pinned to the previous minor version.
 
@@ -77,6 +76,8 @@ The Sequential Subtask Pipeline **MUST** implement the following algorithm:
 - Repository-wide refactors **MUST NOT** occur unless the Story is explicitly classified as a refactor and has its own CR.
 
 ## 3. Change Request Gates
+
+When Autonomy Levels A3–A4 are enabled for a component, the `cost-budget`, `risk-budget`, and `lease-broker` gates SHALL be required. See the [Autonomy Levels appendix](appendix-autonomy-levels.md) for capability definitions.
 
 The following gates are normative required status checks for each CR. Names are normative.
 

--- a/docs/specs/appendix-autonomy-levels.md
+++ b/docs/specs/appendix-autonomy-levels.md
@@ -1,0 +1,19 @@
+---
+title: "Appendix — Autonomy Levels"
+summary: "Normative autonomy level definitions for components opting into A3–A4 operations."
+---
+
+# Appendix — Autonomy Levels
+
+Teams **MAY** adopt autonomy levels. If adopting A3 or A4, the following **SHALL** be enforced: `cost-budget` gate, `risk-budget` gate, Story Lease Broker check, and periodic human ratification.
+
+| Level | Capabilities | Permissions | Required Gates |
+| --- | --- | --- | --- |
+| **A0 — Manual-only** | Humans or hybrid pairs run all subtasks; agents observe. | Read-only access to repositories and telemetry. | Baseline CR gates from [Section 3](adf-spec-v0.5.0.md#3-change-request-gates). |
+| **A1 — Assisted Execution** | Agents propose subtasks and code diffs with human-in-the-loop approvals. | Comment and draft-PR rights; no direct merges. | Baseline CR gates plus Story Lease acquisition logged. |
+| **A2 — Supervised Autonomy** | Agents run SSP subtasks and gate pipelines with human checkpoint sign-off. | Push to Story branches; merges gated by human approval. | Baseline CR gates, Agent Run Ledger (see [handbook](../handbook/evidence-bundle.md#agent-run-ledger)) required. |
+| **A3 — Budget-constrained Autonomy** | Agents execute Story scope end-to-end during active lease windows. | Merge upon green gates within declared budgets. | Baseline CR gates **plus** `cost-budget`, `risk-budget`, and `lease-broker`; Ledger hash chaining required. |
+| **A4 — Continuous Autonomous Delivery** | Agents steward continuous Story queues with periodic human ratification. | Merge and schedule follow-on work inside defined swimlanes. | Baseline CR gates **plus** `cost-budget`, `risk-budget`, `lease-broker`, and ratification checkpoint documented. |
+
+> **Normative note:** Autonomy Levels A3–A4 inherit all obligations from lower levels in addition to the required gates listed above.
+

--- a/docs/specs/appendix-enterprise-mapping.md
+++ b/docs/specs/appendix-enterprise-mapping.md
@@ -1,0 +1,41 @@
+---
+title: "Appendix — Enterprise Mapping"
+summary: "Informative mapping from ADF evidence and metrics to common enterprise audit frameworks."
+---
+
+# Appendix — Enterprise Mapping
+
+This appendix is **informative** and aligns ADF artifacts with common enterprise expectations. Use it to demonstrate how the methodology satisfies compliance and governance inquiries without introducing vendor lock-in.
+
+## Evidence Bundle → SOC2 / ISO Change Evidence
+
+| Evidence Field | SOC2 CC / ISO 27001 Control Alignment | Notes |
+| --- | --- | --- |
+| `requirements-trace.json` | SOC2 CC7.2, ISO 27001 A.8.33 | Demonstrates requirement identification and approval path. |
+| `summary.md` | SOC2 CC1.2, ISO 27001 A.5.23 | Captures approvers, scope, and risk handling for change records. |
+| `gates/` artifacts | SOC2 CC7.3, ISO 27001 A.8.25 | Provides testing, security review, and dependency hygiene evidence. |
+| `preview/` assets | SOC2 CC3.2, ISO 27001 A.8.34 | Shows validation of user impact prior to release. |
+| `provenance/` metadata | SOC2 CC1.1, ISO 27001 A.8.24 | Supports integrity and provenance verification for builds. |
+| `sanitized-logs/` (when present) | SOC2 CC7.4, ISO 27001 A.5.30 | Supplies traceability for incident response with privacy controls. |
+
+## Minimal Metrics → DORA View
+
+| ADF Metric | DORA Dimension | Insight |
+| --- | --- | --- |
+| Lead Time for Changes | Deployment Frequency & Lead Time | Measures velocity from commit to production-ready state. |
+| Change Failure Rate (CFR) | Change Failure Rate | Tracks incident-triggering releases across agents and humans. |
+| Mean Time to Restore (MTTR) | MTTR | Shows recovery agility after detected issues. |
+| Deployment Frequency | Deployment Frequency | Highlights cadence of production releases driven by CRs. |
+| Pulse Increment health | Quality & Reliability | Extends DORA with agent/human mix context for governance reviews. |
+
+## CAB-lite Policy Mapping by Autonomy Level
+
+| Autonomy Level | Human Review Expectations | Policy Notes |
+| --- | --- | --- |
+| A0–A1 | Formal CAB or change approver attends Delivery Pulse prior to release. | Aligns with traditional change advisory workflows while leveraging Story Preview for shared context. |
+| A2 | CAB-lite review occurs asynchronously via Story Preview and Evidence Bundle sign-off before merge. | Human approver confirms `tests-ci` and policy gates, referencing the Agent Run Ledger. |
+| A3 | CAB-lite shifts to periodic ratification of Story Leases and budget adherence. | Delivery Leads document approvals for `cost-budget`, `risk-budget`, and `lease-broker` outputs. |
+| A4 | CAB-lite focuses on governance outcomes during scheduled ratification windows. | Governance board verifies ledger hash chain, risk budgets, and autonomy guardrails. |
+
+> **Reminder:** Autonomy levels beyond A2 remain opt-in; adopting them requires the additional normative gates specified in the [Autonomy Levels appendix](appendix-autonomy-levels.md).
+

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -73,6 +73,15 @@ const sidebars: SidebarsConfig = {
     },
   ],
 
+  vision: [
+    {
+      type: 'category',
+      label: 'Vision',
+      collapsed: false,
+      items: ['vision/autonomy-principle'],
+    },
+  ],
+
   profiles: [
     {
       type: 'category',


### PR DESCRIPTION
## Summary
- link README guidance to the autonomous delivery roadmap, autonomy principle, and new appendices entry
- cross-link the v0.5.0 spec to the roadmap/principle and document the A3–A4 gate requirements via a new autonomy appendix
- document cost-budget, risk-budget, lease-broker, and agent run ledger guidance, plus add the enterprise mapping appendix
- expose the roadmap/vision docs in the sidebar and add placeholder GitLab/Azure DevOps profile stubs


------
https://chatgpt.com/codex/tasks/task_e_68e2e0ce9d448324a3f1bf059cf21da6