### PR TITLE
docs: enforce normative SSP requirements across guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ The Agentic Delivery Framework (ADF) is a vendor-neutral methodology for human +
 4. **Configure platform:** Mirror the [GitHub profile](docs/profiles/github.md) and accompanying [examples](docs/examples/github/) to map gates, protections, and labels.
 5. **Track upgrades:** Review the [CHANGELOG](CHANGELOG.md) for upgrade notes from v0.4.0.
 
+## Method framing
+
+- **Scrum-compatible core:** Preserve Scrum roles, events, and artifacts so Delivery Leads, Product Owners, and Developers operate within a familiar cadence.
+- **Extension practices:** Layer CR-first governance, CR gates, Story Previews, Evidence Bundles, and the Delivery Pulse to "light-purify" execution without adding new ceremonies.
+- **Agent safety rails:** Apply SSP sequencing, workspace runtime guardrails, and telemetry so human and AI contributors stay conflict-free.
+
+**Normative rule:** **SSP is required** for all ADF teams. It is a core practice that enables safe, conflict-free agent execution.
+
+## Conformance levels (L1–L3) — SSP is required
+- **L1 – Supervised Agents:** Agents may propose/commit changes under human oversight. **SSP required** (exclusive Story lease, ordered subtasks, one CR). **CR gates required.** Daily Pulse required.
+- **L2 – Autonomy-Guarded:** Agents can execute outside working hours. **SSP required** with stricter lease timeouts and checkpoint criteria; **CR gates required** with expanded policy set (security, secrets, perf). Daily Pulse required.
+- **L3 – Autonomy-First (24/7):** Agents primarily drive delivery. **SSP required** with hard lease enforcement, rollback/escape-hatch policy; **CR gates required** as policy-as-code; human approval only for risk-tagged changes. Daily Pulse required.
+
 ## Few simple rules
 - **CR-first:** Every code or content change merges via a Change Request targeting a single Story branch.
 - **DoD + CR gates:** `spec-verify`, `tests-ci`, `security-static`, `deps-supply-chain`, `perf-budget`, `framework-guard`, `mode-policy`, `preview-build`, and `human-approval` must pass before merge. Apply `break-glass` only with CAPA follow-up.

--- a/docs/checklists/scrum-purity-scorecard.md
+++ b/docs/checklists/scrum-purity-scorecard.md
@@ -1,0 +1,20 @@
+# Scrum Purity Scorecard
+
+Use this checklist to confirm Scrum fundamentals stay intact while layering ADF safety rails. Score one point for each "Yes" response.
+
+| # | Check | Status (Yes/No) | Evidence |
+| --- | --- | --- | --- |
+| 1 | Product Owner maintains a single Product Backlog ordered toward the Product Goal | [ ] | |
+| 2 | Sprint Goal is declared at Sprint Planning and referenced during Daily Pulse adaptation | [ ] | |
+| 3 | Sprint Backlog is the sole plan of record (no parallel boards or hidden work queues) | [ ] | |
+| 4 | Daily Pulse (≤10 minutes) serves as the Daily Scrum inspect/adapt moment | [ ] | |
+| 5 | Integrated Increment is demonstrated to stakeholders every Sprint Review | [ ] | |
+| 6 | Sprint Retrospective happens each Sprint with explicit improvement actions | [ ] | |
+| 7 | Definition of Done is published, enforced, and includes Story Preview evidence | [ ] | |
+| 8 | Change Requests remain the only merge path (CR-first, single Story branch per Story) | [ ] | |
+| 9 | SSP is enforced (lease, queue, checkpoint, single CR) on all Stories | [ ] | |
+| 10 | CR gates stay intact (`spec-verify`, `tests-ci`, `security-static`, `deps-supply-chain`, `perf-budget`, `framework-guard`, `mode-policy`, `preview-build`, `human-approval`) | [ ] | |
+
+---
+
+This work is licensed under CC BY-SA 4.0.

--- a/docs/handbook/pulse-increment.md
+++ b/docs/handbook/pulse-increment.md
@@ -18,6 +18,7 @@ This guide explains how to produce and govern the Pulse Increment mandated in [S
 
 ## Cadence Overview
 
+- **When agents participate, part of the Pulse is reviewing SSP status (current lease holder, queue, checkpoints) and adapting today’s plan accordingly.**
 - Runs daily at a fixed time aligned with team time zones.
 - Produces a demoable artifact from the `main` branch.
 - Aggregates telemetry: merged CRs, gate outcomes, DORA snapshot, risk register updates, and break-glass usage.

--- a/docs/handbook/ssp.md
+++ b/docs/handbook/ssp.md
@@ -7,6 +7,8 @@ summary: "Step-by-step handbook for running the Sequential Subtask Pipeline with
 
 This guide operationalizes the SSP defined in the [ADF v0.5.0 specification](../specs/adf-spec-v0.5.0.md#2-sequential-subtask-pipeline-ssp). It is optimized for day-one adoption by human or agent executors.
 
+**Status:** **Normative across all conformance levels.** SSP is required whenever software changes are delivered. It enforces an exclusive Story lease, ordered subtask queue, explicit checkpoints, and a single CR.
+
 ## Table of Contents
 - [Roles and Inputs](#roles-and-inputs)
 - [Lease Lifecycle](#lease-lifecycle)

--- a/docs/method-charter.md
+++ b/docs/method-charter.md
@@ -1,0 +1,24 @@
+# Agentic Delivery Framework Method Charter
+
+The Agentic Delivery Framework (ADF) defines the minimal, enforceable guardrails for human and AI contributors to deliver software through Scrum-compatible cadences. It keeps roles, events, and artifacts recognizable while sequencing work through CR-first governance, Story Previews, and Daily Pulse inspection.
+
+**Normative:** The **Sequential Subtask Pipeline (SSP)** is mandatory across ADF. It provides the exclusive Story lease, ordered subtask queue, checkpoints, and single end-of-Story CR required for safe agent execution.
+
+## Mission
+- Preserve Scrum’s simplicity while making agent participation auditable and reversible.
+- Ensure every change flows through a governed workspace runtime with CR gates and Definition of Done evidence.
+- Maintain transparent Story and Sprint states so Delivery Leads, Product Owners, and Developers can intervene quickly.
+
+## Commitments
+- Uphold the Product Goal, Sprint Goal, and Increment as the anchors for planning and inspection.
+- Operate the Daily Pulse as the daily adaptation moment, publishing a Pulse Increment ahead of the sync.
+- Keep Evidence Bundles, Story Previews, and SSP telemetry visible to stakeholders and auditors.
+
+## Invariants
+- Change Requests are the only path to merge; gates map to `spec-verify`, `tests-ci`, `security-static`, `deps-supply-chain`, `perf-budget`, `framework-guard`, `mode-policy`, `preview-build`, and `human-approval`.
+- Story Previews document acceptance evidence before Stories move to Done.
+- SSP sequencing prevents conflicting edits by humans or agents and culminates in a single CR.
+
+---
+
+This work is licensed under CC BY-SA 4.0.


### PR DESCRIPTION
## Summary
- call out SSP as a mandatory core practice in the README, including the updated L1–L3 conformance rails with required SSP language
- mark the SSP handbook as normative across every level and note the Pulse review of SSP status for agent participation
- restate the SSP requirement in the method charter and Scrum Purity Scorecard checklist

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e3039c6aac8324b64c8afe252d8b06