### PR TITLE
docs: add onboarding guides and profiles contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ The Agentic Delivery Framework (ADF) is a vendor-neutral methodology for human +
 - **Appendices:**
   - [Enterprise mapping: Evidence ↔ SOC2/ISO, metrics ↔ DORA, CAB-lite policy](docs/specs/appendix-enterprise-mapping.md).
 
+**Onboarding & Profiles**
+- [Onboarding (Scrum)](docs/handbook/onboarding-scrum.md)
+- [Onboarding (Kanban)](docs/handbook/onboarding-kanban.md)
+- [Profiles contract](docs/profiles/contract.md)
+
 ## Method diagram
 
 ```mermaid

--- a/docs/handbook/onboarding-kanban.md
+++ b/docs/handbook/onboarding-kanban.md
@@ -1,0 +1,5 @@
+# Onboarding for Kanban teams
+
+- **WIP control:** SSP’s Story Lease enforces single-item WIP at the story level; subtasks are sequenced, not parallelized.
+- **Flow metrics:** Use existing [Metrics](metrics.md) for lead time, SSP stall rate, rework rate, and escape defects.
+- **Policies, not ceremonies:** Keep your board; ADF constrains how work flows ([CR-first](../specs/adf-spec-v0.5.0.md#1-core-rules--cr-first-and-evidence), gates, SSP), not your columns. See the [SSP guide](ssp.md) for sequencing patterns.

--- a/docs/handbook/onboarding-scrum.md
+++ b/docs/handbook/onboarding-scrum.md
@@ -1,0 +1,12 @@
+# Onboarding for Scrum teams
+
+ADF preserves product goals and empiricism while Delivery Pulse replaces the daily scrum when asynchronous agents contribute.
+
+| Scrum concept | ADF lens | What changes |
+|---|---|---|
+| Daily Scrum | Delivery Pulse | Async agents produce a Pulse Increment; humans do a 10–15 min inspect-and-adapt on the increment. |
+| Sprint Goal | Product Goal | Same intent; ADF recommends Story Previews to align agent work. |
+| Definition of Done | DoD + CR Gates | Merge only when required gates are green. |
+| Developers | Human/AI/Hybrid | Same accountability; agents run in governed workspaces. |
+
+Cross-train the team on [Story Preview](story-preview.md), [CR Gates](cr-gates.md), and [Metrics](metrics.md) so Scrum cadences stay evidence-driven.

--- a/docs/profiles/contract.md
+++ b/docs/profiles/contract.md
@@ -1,0 +1,20 @@
+# Profiles contract
+
+A platform profile **MUST** document how each required gate is realized or mark it **N/A** with rationale mapped to the governing policy.
+
+**Required fields per gate:**
+- `gate`
+- `mechanism` (action, app, or policy that enforces the gate)
+- `enforcement` (required or optional)
+- `evidence` (artifact URI and hash)
+- `failure-handling`
+- `ownership`
+
+**Minimum sections for every profile:**
+- Repositories or projects in scope
+- Runner trust model
+- Secrets policy
+- Isolation model
+- Audit retention commitments
+
+See the [GitHub profile](github.md) as an informative example of how to express this contract.

--- a/docs/specs/adf-spec-v0.5.0.md
+++ b/docs/specs/adf-spec-v0.5.0.md
@@ -5,6 +5,8 @@ summary: "Normative specification for ADF v0.5.0 including CR-first invariant, S
 
 # Agentic Delivery Framework (ADF) v0.5.0 Specification
 
+> **Conventions used in this spec.** The key words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** are to be interpreted as described in RFC 2119. ADF remains **tool-agnostic**; platform “Profiles” are **informative** bindings and MUST NOT be required to claim conformance.
+
 _Related:_ See **[ADF Roadmap to 24×7 Autonomous Delivery](../roadmaps/adf-roadmap-autonomous-delivery.md)** for adoption steps, and the **[Autonomy-with-Accountability](../vision/autonomy-principle.md)** principle for the north star.
 
 > **Status:** Latest (v0.5.0). v0.4.0 remains normative for teams pinned to the previous minor version.
@@ -31,8 +33,6 @@ _Related:_ See **[ADF Roadmap to 24×7 Autonomous Delivery](../roadmaps/adf-road
 This specification defines the normative requirements for the Agentic Delivery Framework (ADF) v0.5.0. It applies to delivery teams composed of humans, agents, or hybrid pairs building software or documentation artifacts under governance. Non-normative rationale and implementation guidance live in the [handbook](../handbook/README.md) and associated profiles.
 
 ADF v0.5.0 is backward compatible with v0.4.0. Teams MAY remain on v0.4.0 artifacts while assessing the upgrade. The upgrade path is detailed in the [changelog](../CHANGELOG.md) and [handbook conformance guide](../handbook/conformance.md).
-
-> **Tool-agnostic scope.** ADF is a vendor-neutral methodology. Profiles and templates in this repository are **informative** (non-normative) examples; adopters MAY implement equivalent checks and artifacts on any platform.
 
 ## 1. Core Rules — CR-First and Evidence
 
@@ -91,7 +91,7 @@ The following gates are normative required status checks for each CR. Names are 
 8. `preview-build` — Build and attach Story Preview assets.
 9. `human-approval` — Required reviewers approve the CR when mandated by policy.
 
-**Break-Glass Protocol:** Applying the `break-glass` label **MAY** bypass Gates 3–7. Usage **MUST** be approved by a designated lead and **MUST** auto-file a corrective and preventive action (CAPA) item for the next Sprint. The Delivery Pulse **MUST** flag all break-glass merges.
+**Break-glass.** May be invoked **only** by the Delivery Lead for time-critical remediation. When used, the CR **MUST** (a) record `break_glass.used=true` in the Evidence Bundle with reason; (b) open a **CAPA** issue within 24 hours; (c) pass all gates retroactively within 72 hours or revert.
 
 ## 4. Story Preview
 
@@ -134,6 +134,23 @@ Each merged CR **MUST** generate an Evidence Bundle stored at `/artifacts/eviden
 - `sanitized-logs/` directory (optional per policy) containing redacted execution logs.
 
 Evidence Bundles **MUST** be referenced during audits and Delivery Pulse reviews.
+
+**Minimal JSON descriptor:**
+
+```json
+{
+  "id": "uuid",
+  "cr": "org/repo#123",
+  "gate": "security-static",
+  "actor": {"type":"agent|human","id":"<principal>"},
+  "artifact": {"uri":"<https://...>", "sha256":"<hash>"},
+  "result": "pass|fail|waived",
+  "timestamp": "2025-10-06T00:00:00Z",
+  "retention_days": 180,
+  "notes": "optional",
+  "break_glass": {"used": false, "reason": "", "capa_issue": ""}
+}
+```
 
 ## 8. Metrics Vocabulary
 

--- a/reports/adf-micro-patch-20251006.md
+++ b/reports/adf-micro-patch-20251006.md
@@ -1,0 +1,11 @@
+# ADF micro-patch report (2025-10-06)
+
+| Path | Action | Reason/Detector |
+|---|---|---|
+| docs/specs/adf-spec-v0.5.0.md (RFC-2119) | UPDATED | "RFC 2119" block absent; inserted conventions note. |
+| docs/specs/adf-spec-v0.5.0.md (Break-glass) | UPDATED | No Break-glass + CAPA + 72 hours rule present. |
+| docs/specs/adf-spec-v0.5.0.md (Evidence schema) | UPDATED | Evidence Bundle JSON keys missing; added minimal descriptor. |
+| docs/handbook/onboarding-scrum.md | CREATED | File did not exist. |
+| docs/handbook/onboarding-kanban.md | CREATED | File did not exist. |
+| docs/profiles/contract.md | CREATED | Contract page absent under docs/profiles/. |
+| README.md links | UPDATED | Onboarding & Profiles links missing under docs section. |


### PR DESCRIPTION
## Summary
- clarify RFC 2119 conventions, break-glass guardrails, and evidence bundle schema in the ADF v0.5.0 spec while reiterating tool-agnostic scope
- add Scrum and Kanban onboarding lenses plus a profiles contract guide with links from the README
- record the 2025-10-06 micro-patch actions in the reporting ledger

## Testing
- not run (documentation-only)

## Checklist
- [x] Links resolve locally
- [x] Terminology matches canonical gate and artifact names
- [x] Tool/vendor neutrality confirmed

Report: [reports/adf-micro-patch-20251006.md](reports/adf-micro-patch-20251006.md)

------
https://chatgpt.com/codex/tasks/task_e_68e30919c0848324a7f94848e7623417