### PR TITLE
docs: linearize method diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,22 @@ The Agentic Delivery Framework (ADF) is a vendor-neutral methodology for human +
 
 ```mermaid
 graph TD
-  PO[PO] -->|Plan| SP[Sprint Planning]
-  DL[Delivery Lead] --> SP
-  SP --> ST[Story + SSP]
-  ST --> CR[Change Request]
-  CR --> GATES[CR Gates]
-  GATES -->|green| MERGE[Merge]
+  PO[Product Owner] -->|Story Preview| READY[Story Ready]
+  DL[Delivery Lead] -->|Lease Story| READY
+  READY --> SSP[Sequential Subtask Pipeline]
+  SSP --> CR[Change Request]
+  CR --> SPEC[spec-verify]
+  SPEC --> TESTS[tests-ci]
+  TESTS --> SEC[security-static]
+  SEC --> DEPS[deps-supply-chain]
+  DEPS --> PERF[perf-budget]
+  PERF --> FRAMEWORK[framework-guard]
+  FRAMEWORK --> MODE[mode-policy]
+  MODE --> PREVIEW[preview-build]
+  PREVIEW --> HUMAN[human-approval]
+  HUMAN --> MERGE[Merge]
   MERGE --> PULSE[Pulse Increment]
-  PULSE --> REVIEW[Review/Retro]
+  PULSE --> REVIEW[Review / Retro]
 ```
 
 ## What’s inside


### PR DESCRIPTION
## Summary
- Linearized the README method diagram to reflect a single pathway from Story Preview through Merge and Review.
- Highlighted the Sequential Subtask Pipeline and normative CR gates using canonical terminology while preserving vendor neutrality.

## Testing
- Not run (docs-only change)

ADF remains tool-agnostic; the updated diagram communicates methodology flow without platform-specific dependencies.

### Checklist
- [x] Verified no broken or new links introduced.
- [x] Confirmed terminology matches canonical gate and artifact names.
- [x] Completed neutrality scan for vendor-specific language.


------
https://chatgpt.com/codex/tasks/task_e_68e30c1c57588324b0471fca0302e011